### PR TITLE
feat: improve GitHub report workflow

### DIFF
--- a/cypress/integration/gh-issue-open.spec.js
+++ b/cypress/integration/gh-issue-open.spec.js
@@ -9,7 +9,7 @@ describe('Line Options', () => {
 
   it('3 Dots Menu', () => {
     cy.get( '[data-cy=menu-button-dots]' ).click()
-    cy.matchValue( '.menu-item', 'Submit Correction' )
+    cy.matchValue( '.menu-item', 'Report an issue' )
   })
 
 })

--- a/frontend/src/components/LineView.js
+++ b/frontend/src/components/LineView.js
@@ -158,7 +158,7 @@ const LineView = ( {
                   </MenuItem>
                 </Menu>
                 )}
-              position="bottom"
+              position="left"
             >
               <IconButton icon="ellipsis-v" onClick={toggleMenu} data-cy="menu-button-dots" />
             </Popover>

--- a/frontend/src/components/LineView.js
+++ b/frontend/src/components/LineView.js
@@ -154,7 +154,7 @@ const LineView = ( {
                   <MenuItem
                     onClick={closeMenuAfter( submitCorrection )}
                   >
-                    Submit Correction
+                    Report an issue
                   </MenuItem>
                 </Menu>
                 )}

--- a/frontend/src/components/LineView.js
+++ b/frontend/src/components/LineView.js
@@ -82,7 +82,7 @@ const LineView = ( {
 
   const { translations, gurmukhi } = line || {}
 
-  const submitCorrection = () => window.open( getIssueUrl( { page, ...source, ...line } ), 'blank' )
+  const submitCorrection = () => window.open( getIssueUrl( { ...source, ...line } ), 'blank' )
 
   const { pathname } = useLocation()
   const history = useHistory()

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -3,7 +3,7 @@ import newGithubIssueUrl from 'new-github-issue-url'
 export const getIssueUrl = ( {
   id,
   gurmukhi,
-  page,
+  sourcePage: page,
   nameEnglish,
 } ) => newGithubIssueUrl( {
   user: 'ShabadOS',

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,7 +1,9 @@
 import newGithubIssueUrl from 'new-github-issue-url'
+import { toUnicode, stripVishraams, stripEndings } from 'gurmukhi-utils'
 
 export const getIssueUrl = ( {
   id,
+  shabadId,
   gurmukhi,
   sourcePage: page,
   nameEnglish,
@@ -10,17 +12,13 @@ export const getIssueUrl = ( {
   repo: 'Database',
   labels: [ 'correction', nameEnglish ],
   title: `${id}`,
-  body: `
-<!-- Instructions are hidden. Use the preview tab. Tutorial: https://database.shabados.com -->
+  body: `<!-- Do not edit this section. Check out the preview tab. Learn more about proofreading: https://viewer.shabados.com -->
+---
+Database was \`${gurmukhi}\` on ${new Date().toISOString()}. See line in [Shabad OS Viewer](https://viewer.shabados.com/line/${id}) or [GurbaniNow](https://gurbaninow.com/shabad/${shabadId}/${id}).
 
-| Key | Value |
-| --- | ----- |
-View | https://database.shabados.com/line/${id}
-Source | ${nameEnglish}
-Page | ${page}
-ID | ${id}
-Line | ${gurmukhi}
-
+> ${stripEndings( stripVishraams( toUnicode( gurmukhi ) ) )}
+> ${nameEnglish}, ${page}
+---
 <!-- Add details & attach image(s) below. Provide context & indication. Example: https://github.com/ShabadOS/database/issues/812 -->
 
 `,


### PR DESCRIPTION
### Summary of PR
A few things were outdated for the report issue workflow. For one, a user cannot submit corrections to the database using an issue, they can simply "create issues". The new issue template includes a date, so it's more clear to anyone reading that what is in the issue may or may not reflect what is currently in the database. Added an alternate viewer a la GurbaniNow.

### Time spent on PR
1 hour

### Reviewers
@Harjot1Singh 