### PR TITLE
ci: add continuous next releases on push to main

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,0 +1,129 @@
+name: Release Next
+# Same as release-latest, but has no integration step and does not push back to `main`.
+# To be refactored into a common once we have support for pushing semver docker images in shabados/actions#83
+# and support for reading the version from tags in actions tracked in shabados/actions#84.
+
+concurrency: release
+
+on:
+  branches:
+    - main    
+
+jobs:
+  prepare:
+    runs-on: ubuntu-20.04
+    outputs:
+      release-version: ${{ steps.bump-version.outputs.next }}
+    steps:
+      - uses: shabados/actions/setup-git-identity@release/v1
+        with:
+          user: Shabad OS Bot
+          email: team@shabados.com
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_BOT_TOKEN }}
+
+      # Todo: will be replaced in #shabados/action#84
+      - name: Sync package.json version with git tag
+        run: |
+          npm version $(git tag --sort=-version:refname | head -n1) --no-git-tag-version
+          git commit --allow-empty -m "build: synchronise package.json version with latest git tag"
+
+      - uses: shabados/actions/bump-version@release/v1
+        id: bump-version
+
+      - uses: shabados/actions/generate-changelog@release/v1
+
+      - name: Upload workspace
+        uses: actions/upload-artifact@v2
+        with:
+          name: release-workspace
+          path: ${{ github.workspace }}
+
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        context: [backend, frontend]
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and export
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.context }}
+          tags: |
+            # Todo: to be converted into semver prerelease format via shabados/actions#83
+            shabados/database-viewer-${{ matrix.context }}:next-${{ github.sha }}
+            ghcr.io/shabados/database-viewer-${{ matrix.context }}:next-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/database-viewer-${{ matrix.context }}.tar
+
+      - name: Upload Docker image
+        uses: actions/upload-artifact@v2
+        with:
+          name: database-viewer-${{ matrix.context }}
+          path: /tmp/database-viewer-${{ matrix.context }}.tar
+
+  publish-github:
+    runs-on: ubuntu-20.04
+    needs: [prepare, integrate]
+    steps:
+      - uses: shabados/actions/setup-git-identity@release/v1
+        with:
+          user: Shabad OS Bot
+          email: team@shabados.com
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_BOT_TOKEN }}
+
+      - uses: shabados/actions/publish-github@release/v1
+        with:
+          github_token: ${{ secrets.GH_BOT_TOKEN }}
+          release_version: ${{ needs.prepare.outputs.release-version }}
+
+  publish:
+    runs-on: ubuntu-20.04
+    needs: integrate
+    strategy:
+      fail-fast: false
+      matrix:
+        context: [backend, frontend]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Download ${{ matrix.context }} Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: database-viewer-${{ matrix.context }}
+          path: /tmp
+      
+      - name: Load image
+        run: docker load --input /tmp/database-viewer-${{ matrix.context }}.tar
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: shabados
+          password: ${{ secrets.DOCKERHUB_BOT_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: shabados-bot
+          password: ${{ secrets.GH_BOT_TOKEN }}
+
+      - name: Push ${{ matrix.context }} images
+        run: |
+          docker push -a shabados/database-viewer-${{ matrix.context }}
+          docker push -a ghcr.io/shabados/database-viewer-${{ matrix.context }}


### PR DESCRIPTION
## Summary

As per #240. this PR adds support to publish continuous next releases by:

- using tags to read the previous release version
- sync up the package.json version with the latest git tag
- run the bump version as normal
- run the rest of the flow as normal

Note: this means that next releases will have git tags that are DETACHED from the main branch, as the commits are never pushed back. I think this is ok for next releases as we don't really care about the package version bump change at that point.

## Ticket
Related #240