### PR TITLE
ci: upgrade to shabados/actions@release/v2 and remove unnecessary steps

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       release-version: ${{ steps.bump-version.outputs.next }}
     steps:
-      - uses: shabados/actions/setup-git-identity@release/v1
+      - uses: shabados/actions/setup-git-identity@release/v2
         with:
           user: Shabad OS Bot
           email: team@shabados.com
@@ -21,16 +21,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_BOT_TOKEN }}
 
-      # Todo: will be replaced in #shabados/action#84
-      - name: Sync package.json version with git tag
-        run: |
-          npm version $(git tag --sort=-taggerdate | head -n1) --no-git-tag-version --allow-same-version
-          git commit -a --allow-empty -m "build: synchronise package.json version with latest git tag"
-
-      - uses: shabados/actions/bump-version@release/v1
+      - uses: shabados/actions/bump-version@release/v2
         id: bump-version
 
-      - uses: shabados/actions/generate-changelog@release/v1
+      - uses: shabados/actions/generate-changelog@release/v2
 
       - name: Upload workspace
         uses: actions/upload-artifact@v2
@@ -72,7 +66,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build
     steps:
-      - uses: shabados/actions/setup-git-identity@release/v1
+      - uses: shabados/actions/setup-git-identity@release/v2
         with:
           user: Shabad OS Bot
           email: team@shabados.com
@@ -85,7 +79,7 @@ jobs:
 
       - run: cat package.json
 
-      - uses: shabados/actions/integrate-commits@release/v1
+      - uses: shabados/actions/integrate-commits@release/v2
         with:
           github_token: ${{ secrets.GH_BOT_TOKEN }}
 
@@ -93,7 +87,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [prepare, integrate]
     steps:
-      - uses: shabados/actions/setup-git-identity@release/v1
+      - uses: shabados/actions/setup-git-identity@release/v2
         with:
           user: Shabad OS Bot
           email: team@shabados.com
@@ -103,7 +97,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_BOT_TOKEN }}
 
-      - uses: shabados/actions/publish-github@release/v1
+      - uses: shabados/actions/publish-github@release/v2
         with:
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           release_version: ${{ needs.prepare.outputs.release-version }}

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,8 +1,7 @@
 name: Release Next
 
 # Same as release-latest, but has no integration step and does not push back to `main`.
-# To be refactored into a common once we have support for pushing semver docker images in shabados/actions#83
-# and support for reading the version from tags in actions tracked in shabados/actions#84.
+# To be refactored into a common once we have support for pushing semver docker images in shabados/actions#83.
 
 concurrency: release
 
@@ -18,7 +17,7 @@ jobs:
     outputs:
       release-version: ${{ steps.bump-version.outputs.next }}
     steps:
-      - uses: shabados/actions/setup-git-identity@release/v1
+      - uses: shabados/actions/setup-git-identity@release/v2
         with:
           user: Shabad OS Bot
           email: team@shabados.com
@@ -28,18 +27,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_BOT_TOKEN }}
 
-      # Todo: will be replaced in #shabados/action#84
-      - name: Sync package.json version with git tag
-        run: |
-          npm version $(git tag --sort=-taggerdate | head -n1) --no-git-tag-version --allow-same-version
-          git commit -a --allow-empty -m "build: synchronise package.json version with latest git tag"
-
-      - uses: shabados/actions/bump-version@release/v1
+      - uses: shabados/actions/bump-version@release/v2
         id: bump-version
         with:
           prerelease: true
 
-      - uses: shabados/actions/generate-changelog@release/v1
+      - uses: shabados/actions/generate-changelog@release/v2
 
       - name: Upload workspace
         uses: actions/upload-artifact@v2
@@ -82,7 +75,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [prepare, build]
     steps:
-      - uses: shabados/actions/setup-git-identity@release/v1
+      - uses: shabados/actions/setup-git-identity@release/v2
         with:
           user: Shabad OS Bot
           email: team@shabados.com
@@ -92,7 +85,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_BOT_TOKEN }}
 
-      - uses: shabados/actions/publish-github@release/v1
+      - uses: shabados/actions/publish-github@release/v2
         with:
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           release_version: ${{ needs.prepare.outputs.release-version }}


### PR DESCRIPTION
### Summary of PR
Updates to Shabad OS actions v2!

This means that bump-version now reads the latest version from git tags, not package.json, meaning that we can remove the synchronise step.
