### PR TITLE
ci: call correct release workflow

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -7,6 +7,6 @@ concurrency: release
 
 jobs:
   release:
-    uses: shabados/actions/.github/workflows/release.yml@main
+    uses: shabados/viewer/.github/workflows/release.yml@main
     secrets:
       GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -10,7 +10,7 @@ concurrency: release
 
 jobs:
   release:
-    uses: shabados/actions/.github/workflows/release.yml@main
+    uses: shabados/viewer/.github/workflows/release.yml@main
     with:
       prerelease: true
     secrets:


### PR DESCRIPTION
### Summary of PR

In #364, the incorrect reusable workflow from Shabad OS actions was referenced. This PR uses the workflow from this repo!