### PR TITLE
ci: add github token as secret to release workflow

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -10,3 +10,5 @@ jobs:
     uses: shabados/viewer/.github/workflows/release.yml@main
     secrets:
       GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DOCKERHUB_BOT_TOKEN: ${{ secrets.DOCKERHUB_BOT_TOKEN }}

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -15,3 +15,5 @@ jobs:
       prerelease: true
     secrets:
       GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DOCKERHUB_BOT_TOKEN: ${{ secrets.DOCKERHUB_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
     secrets:
       GH_BOT_TOKEN:
         required: true
+      GITHUB_TOKEN:
+        required: true
+      DOCKERHUB_BOT_TOKEN:
+        required: true
 
 jobs:
   prepare:


### PR DESCRIPTION
### Summary of PR

Turns out reusable workflows do not pass through secrets by default....
